### PR TITLE
Render CLI v1.0.0

### DIFF
--- a/Formula/render.rb
+++ b/Formula/render.rb
@@ -1,8 +1,8 @@
 class Render < Formula
   desc "Command-line interface for Render"
   homepage "https://github.com/render-oss/cli"
-  url "https://github.com/render-oss/cli/archive/refs/tags/v0.8.7.tar.gz"
-  sha256 "d5ab6e7e810edc22d45d1cd4800480e388bbb445c79f2fe770ab25b640fb3870"
+  url "https://github.com/render-oss/cli/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "bbc1a37e541c2bbfcb96bbff043fe4f9bcb1e80c70a5224639f1e0a99c0e2cc1"
   license "Apache-2.0"
   head "https://github.com/render-oss/cli.git", branch: "main"
 

--- a/Formula/render.rb
+++ b/Formula/render.rb
@@ -1,20 +1,28 @@
 class Render < Formula
-  version = "0.8.7"
-  tag     = "v#{version}"
-  desc "Command-line interface for Render (Beta version)"
+  desc "Command-line interface for Render"
   homepage "https://github.com/render-oss/cli"
-  url "https://github.com/render-oss/cli.git",
-      tag:      tag,
-      revision: "dd2a85c107764fa347e636c5dd27808b06ce9ad4"
+  url "https://github.com/render-oss/cli/archive/refs/tags/v0.8.7.tar.gz"
+  sha256 "d5ab6e7e810edc22d45d1cd4800480e388bbb445c79f2fe770ab25b640fb3870"
   license "Apache-2.0"
+  head "https://github.com/render-oss/cli.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w -X 'github.com/renderinc/cli/pkg/cfg.Version=#{version}'")[1..]
+    ldflags = %W[
+      -s -w
+      -X github.com/renderinc/cli/pkg/cfg.Version=#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do
     assert_match "Usage:", shell_output("#{bin}/render --help")
-    assert_match "render version" + version, shell_output("#{bin}/render --version")
+    assert_match version.to_s, shell_output("#{bin}/render --version")
   end
 end


### PR DESCRIPTION
Adds the 1.0.0 release and updates the Brewfile to be in line with what's required for Homebrew core.